### PR TITLE
vectorized numpy version

### DIFF
--- a/test.py
+++ b/test.py
@@ -127,3 +127,35 @@ print('result:', ee.kldiv(sample1, sample2))
 print("should be infinite for totally disjoint distributions (but this estimator has an upper bound like log(dist) between disjoint prob. masses)")
 sample2 = [[3 + 2 * random.random()] for i in range(300)]
 print('result:', ee.kldiv(sample1, sample2))
+
+
+def test_discrete(size=1000, y_func=lambda x: x**2):
+    print("\nTest discrete.")
+    from collections import defaultdict
+    information = defaultdict(list)
+    y_entropy = defaultdict(list)
+    x_entropy = []
+    for trial in range(10):
+        x = np.random.randint(low=0, high=10, size=size)
+
+        y_random = np.random.randint(low=53, high=53 + 5, size=size)
+        y_deterministic = y_func(x)
+        noise = np.random.randint(low=0, high=10, size=size)
+        y_noisy = y_deterministic + noise
+
+        information['random'].append(ee.midd(x, y_random))
+        information['deterministic'].append(ee.midd(x, y_deterministic))
+        information['noisy'].append(ee.midd(x, y_noisy))
+
+        x_entropy.append(ee.entropyd(x))
+        y_entropy['random'].append(ee.entropyd(y_random))
+        y_entropy['deterministic'].append(ee.entropyd(y_deterministic))
+        y_entropy['noisy'].append(ee.entropyd(y_noisy))
+    x_entropy = np.mean(x_entropy)
+    for experiment_name in information.keys():
+        max_information = min(x_entropy, np.mean(y_entropy[experiment_name]))
+        print(f"{experiment_name}: I(X; Y) = {np.mean(information[experiment_name]):.4f} "
+              f"± {np.std(information[experiment_name]):.4f} (maximum possible {max_information:.4f})")
+
+
+test_discrete()


### PR DESCRIPTION
I've been using your NPEET package to estimate mutual information between hidden layers of neural nets and decided to vectorize its implementation to match numpy style. Consider merging.
Here is the old versus new timings.

```python
import numpy as np
import npeet.entropy_estimators as ee  # current list version
import npeet.npeet as ee2  # vectorized numpy version

n = 1000


def to_list(x):
    return list(map(list, x))


def to_tuple(x):
    return list(map(tuple, x))


def setup_x():
    return np.random.rand(n, 10)


def setup_y():
    return np.random.rand(n, 3)


def setup_z():
    return np.random.rand(n, 5)


print('mi(x, y):')
%timeit ee.mi(setup_x().tolist(), setup_y().tolist())
%timeit ee2.mi(setup_x(), setup_y())

print('ctc(x, y):')
%timeit ee.ctc(setup_x().tolist(), setup_y().tolist())
%timeit ee2.ctc(setup_x(), setup_y())

print('cmi(x, y, z):')
%timeit ee.cmi(setup_x().tolist(), setup_y().tolist(), z=setup_z().tolist())
%timeit ee2.mi(setup_x(), setup_y(), z=setup_z())

print('micd(x, y):')
%timeit ee.micd(setup_x().tolist(), np.random.randint(0, 10, (n, 3)).tolist(), warning=False)
%timeit ee2.micd(setup_x(), np.random.randint(0, 10, (n, 3)), warning=False)


for i in range(10):
    x, y = setup_x(), setup_y()
    x_other = setup_x()
    z = setup_z()
    x_list = to_list(x)
    y_list = to_list(y)

    x_discrete = np.random.randint(0, 10, size=x.shape)
    y_discrete = np.random.randint(0, 10, size=y.shape)
    z_discrete = np.random.randint(0, 10, size=z.shape)

    assert np.isclose(ee2.entropy(x), ee.entropy(x_list))
    assert np.isclose(ee2.centropy(x, y), ee.centropy(x_list, y_list))
    assert np.isclose(ee2.tc(x), ee.tc(x_list))
    assert np.isclose(ee2.ctc(x, y), ee.ctc(x_list, y_list))
    assert np.isclose(ee2.corex(x, y), ee.corex(x_list, y_list))
    assert np.isclose(ee2.mi(x, y), ee.mi(x_list, y_list))
    assert np.isclose(ee2.mi(x, y, z=z), ee.cmi(x_list, y_list, z))
    assert np.isclose(ee2.kldiv(x, x_other), ee.kldiv(x_list, to_list(x_other)))

    assert np.isclose(ee2.midd(x_discrete, y_discrete), ee.midd(to_tuple(x_discrete), to_tuple(y_discrete)))
    assert np.isclose(ee2.cmidd(x_discrete, y_discrete, z_discrete),
                      ee.cmidd(to_tuple(x_discrete), to_tuple(y_discrete), to_tuple(z_discrete)))
    assert np.isclose(ee2.micd(x, y_discrete, warning=False), ee.micd(x_list, y_discrete.tolist(), warning=False))

```

Output
```
mi(x, y):
194 ms ± 1.25 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
83.2 ms ± 2.62 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
ctc(x, y):
1.74 s ± 1.67 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
62.5 ms ± 16.4 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
cmi(x, y, z):
309 ms ± 2.04 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
167 ms ± 1.92 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
micd(x, y):
161 ms ± 727 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
45.1 ms ± 988 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

`avgdigamma` is the most time consuming function but I don't know how to vectorize the internal for-loop.
